### PR TITLE
Remove misleading sentence from privacy policy

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -22,8 +22,7 @@ Black Hole Vision does not use any third-party services that collect user data.
 
 ## Children’s Privacy
 
-Black Hole Vision is not intended for use by children under the age of 13. We
-do not knowingly collect any personal data from children under 13.
+We do not knowingly collect any personal data from children under 13.
 
 ## Changes to This Privacy Policy
 


### PR DESCRIPTION
I'm assuming you probably just copied the privacy policy text from some template. The privacy policy currently states "Black Hole Vision is not intended for use by children under the age of 13" even though there is probably no reason why children <13 shouldn't be able to use it. The App Store listing also says the app is designed for people ≥4 years old.

![image](https://github.com/user-attachments/assets/8d6f3f9b-57dc-44ab-9f24-ea024e92fe7d)
